### PR TITLE
fix rendering a folder of panel dashboards

### DIFF
--- a/bokeh_root_cmd/main.py
+++ b/bokeh_root_cmd/main.py
@@ -51,7 +51,7 @@ class BokehServer:
         """
         if hasattr(self, 'html_file'):
             if self.html_file is None:
-                self.html_file = tempfile.NamedTemporaryFile("wt")
+                self.html_file = tempfile.NamedTemporaryFile("wt", suffix='.html')
                 with open(self._get_default_index_html(), "rt") as f:
                     for r in f.readlines():
                         r = re.sub(r'\{\{\s*prefix\s*\}\}', self.prefix, r)


### PR DESCRIPTION
fixes error preventing bokeh-root-cmd handling a folder of dashboards.  The page below doesn't load prior to this fix.
![image](https://user-images.githubusercontent.com/23342526/133160901-3c238b11-958e-4aef-98c0-1241265c0bcb.png)
